### PR TITLE
FIX: fixing history navigation and pathname in version web

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import Main from './src/components/Main.jsx'
-import { NativeRouter } from 'react-router-native'
 import { StatusBar } from 'expo-status-bar'
 import { ApolloProvider } from '@apollo/client'
 import createApolloClient from './src/utils/apolloClient.js'
+import Router from './src/components/Router'
 
 const apolloClient = createApolloClient()
 
@@ -11,9 +11,9 @@ export default function App () {
   return (
     <ApolloProvider client={apolloClient}>
       <StatusBar style='light' />
-      <NativeRouter>
+      <Router>
         <Main />
-      </NativeRouter>
+      </Router>
     </ApolloProvider>
   )
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",
     "react-native-web": "~0.13.12",
+    "react-router-dom": "^5.2.0",
     "react-router-native": "^5.2.0",
     "yup": "^0.32.9"
   },

--- a/src/components/Router/Router.jsx
+++ b/src/components/Router/Router.jsx
@@ -1,0 +1,1 @@
+export { NativeRouter as Router } from "react-router-native"

--- a/src/components/Router/Router.web.jsx
+++ b/src/components/Router/Router.web.jsx
@@ -1,0 +1,1 @@
+export { BrowserRouter as Router } from "react-router-dom"

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -1,0 +1,1 @@
+export { Router as default } from './Router'


### PR DESCRIPTION
Hola @midudev, soy Kitonz del twitch y también patreon tuyo.

Te cuento, la  librería `react-router-native`  no es 100% compatible con la versión web, no puedo hacerte video para adjuntar, pero se pueden ver fácilmente los problemas:

- No gestiona el `history` del navegador, por lo que no podemos darle al botón de atrás del navegador al cambiar entre varias páginas, o si le damos nos irá a la pagina anterior a la de entrar en la web.
- No cambia el `window.location.pathname` por lo que siempre estaremos en la url en la que entramos del proyecto.

Ya se que los videos ván enfocados sólo a la parte nativa, pero te dejo la solución a la que llegué a raiz de https://codersera.com/blog/react-native-web-tutorials-your-first-hybrid-app/ , comentarte que para todos los demás componentes se puede seguir usando la librería native, pero el Router si necesita esta distinción.

Saludos!

